### PR TITLE
Fix UNIX/Linux Compilation

### DIFF
--- a/plugin/SN76489.jucer
+++ b/plugin/SN76489.jucer
@@ -75,7 +75,7 @@
         <MODULEPATH id="juce_audio_formats" path="../modules/juce/modules"/>
         <MODULEPATH id="juce_audio_processors" path="../modules/juce/modules"/>
         <MODULEPATH id="juce_audio_plugin_client" path="../modules/juce/modules"/>
-        <MODULEPATH id="dRowAudio" path="../modules/drowaudio/module"/>
+        <MODULEPATH id="dRowAudio" path="../modules/dRowAudio/module"/>
         <MODULEPATH id="juce_audio_utils" path="../modules/juce/modules"/>
         <MODULEPATH id="gin" path="../modules/gin/modules"/>
         <MODULEPATH id="gin_plugin" path="../modules/gin/modules"/>
@@ -121,7 +121,7 @@
         <MODULEPATH id="juce_audio_formats" path="../modules/juce/modules"/>
         <MODULEPATH id="juce_audio_processors" path="../modules/juce/modules"/>
         <MODULEPATH id="juce_audio_plugin_client" path="../modules/juce/modules"/>
-        <MODULEPATH id="dRowAudio" path="../modules/drowaudio/module"/>
+        <MODULEPATH id="dRowAudio" path="../modules/dRowAudio/module"/>
         <MODULEPATH id="juce_audio_utils" path="../modules/juce/modules"/>
         <MODULEPATH id="gin" path="../modules/gin/modules"/>
         <MODULEPATH id="gin_plugin" path="../modules/gin/modules"/>
@@ -156,7 +156,7 @@
         <MODULEPATH id="juce_audio_formats" path="../modules/juce/modules"/>
         <MODULEPATH id="juce_audio_devices" path="../modules/juce/modules"/>
         <MODULEPATH id="juce_audio_basics" path="../modules/juce/modules"/>
-        <MODULEPATH id="dRowAudio" path="../modules/drowaudio/module"/>
+        <MODULEPATH id="dRowAudio" path="../modules/dRowAudio/module"/>
         <MODULEPATH id="gin" path="../modules/gin/modules"/>
         <MODULEPATH id="gin_plugin" path="../modules/gin/modules"/>
         <MODULEPATH id="gin_dsp" path="../modules/gin/modules"/>


### PR DESCRIPTION
dRowAudio folder path in Projucer needs to be case sensitive for non-Windows OSs